### PR TITLE
Fix attribute error in case request has no object param

### DIFF
--- a/source/plugin.py
+++ b/source/plugin.py
@@ -89,6 +89,9 @@ def pytest_fixture_setup(request, fixturedef) -> None:
     """
     Start group "FIXTURE FixtureName"
     """
+    # all pytest fixtures might not have request.param:
+    if not hasattr(request, 'param'):
+        request.param = ''
     fixture_type = f'FIXTURE ({fixturedef.scope})'
     fixture_name = request.fixturename
     request_param = request.param

--- a/source/plugin.py
+++ b/source/plugin.py
@@ -89,12 +89,9 @@ def pytest_fixture_setup(request, fixturedef) -> None:
     """
     Start group "FIXTURE FixtureName"
     """
-    # all pytest fixtures might not have request.param:
-    if not hasattr(request, 'param'):
-        request.param = ''
     fixture_type = f'FIXTURE ({fixturedef.scope})'
     fixture_name = request.fixturename
-    request_param = request.param
+    request_param = request.param if hasattr(request, 'param') else ''
     param_marks = list(filter(lambda m: m.name == 'parametrize',
                               request.node.own_markers))
     if any(param_marks):


### PR DESCRIPTION
Some fixtures seems to not have request.param in place. Anyway, for the fixtures that does not have parameters, param attribute seems to be mostly an empty string.

This PR fixes the attribute error by setting empty string as request.param for fixtures that do not have param attribute.